### PR TITLE
WIP: Add checksums to on-disk cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -747,6 +747,9 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytes-utils"
@@ -1951,6 +1954,7 @@ dependencies = [
  "aws-sdk-sts",
  "base16ct",
  "base64ct",
+ "bincode",
  "built",
  "bytes",
  "clap 4.3.9",
@@ -1977,6 +1981,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "regex",
+ "serde",
  "serde_json",
  "sha2",
  "shuttle",
@@ -2813,18 +2818,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.180"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea67f183f058fe88a4e3ec6e2788e003840893b91bac4559cabedd00863b3ed"
+checksum = "91d3c334ca1ee894a2c6f6ad698fe8c435b76d504b13d436f0685d648d6d96f7"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.180"
+version = "1.0.190"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24e744d7782b686ab3b73267ef05697159cc0e5abbed3f47f9933165e5219036"
+checksum = "67c5609f394e5c2bd7fc51efda478004ea80ef42fee983d5c67a65e34f32c0e3"
 dependencies = [
  "proc-macro2 1.0.63",
  "quote 1.0.29",

--- a/mountpoint-s3/Cargo.toml
+++ b/mountpoint-s3/Cargo.toml
@@ -14,7 +14,7 @@ anyhow = { version = "1.0.64", features = ["backtrace"] }
 async-channel = "1.8.0"
 async-lock = "2.6.0"
 async-trait = "0.1.57"
-bytes = "1.2.1"
+bytes = { version = "1.2.1", features = ["serde"] }
 clap = { version = "4.1.9", features = ["derive"] }
 crc32c = "0.6.3"
 ctrlc = { version = "3.2.3", features = ["termination"] }
@@ -37,6 +37,8 @@ time = { version = "0.3.17", features = ["macros", "formatting"] }
 const_format = "0.2.30"
 serde_json = "1.0.95"
 base64ct = { version = "1.6.0", features = ["std"] }
+serde = { version = "1.0.190", features = ["derive"] }
+bincode = "1.3.3"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 procfs = { version = "0.15.1", default-features = false }

--- a/mountpoint-s3/src/lib.rs
+++ b/mountpoint-s3/src/lib.rs
@@ -8,6 +8,7 @@ pub mod logging;
 pub mod metrics;
 pub mod prefetch;
 pub mod prefix;
+mod serde;
 mod sync;
 mod upload;
 

--- a/mountpoint-s3/src/serde.rs
+++ b/mountpoint-s3/src/serde.rs
@@ -1,0 +1,56 @@
+//! Serializers for types we don't own and don't already have a Serialize implementation.
+//!
+//! The way we get around this is by implementing a wrapping type
+//! and using this in structures where we need to serialize/deserialize.
+
+use std::ops::Deref;
+
+use mountpoint_s3_crt::checksums::crc32c::Crc32c;
+use serde::{Deserialize, Deserializer, Serialize};
+
+/// Serializable wrapper for [Crc32c].
+///
+/// [Deref] is implemented to allow most access to the underlying type to be seamless,
+/// and [From<Crc32c>] is implemented for easy wrapping using `.into()`.
+///
+/// [Crc32c] is owned by mountpoint-s3 (under the `mountpoint-s3-crt` crate).
+/// An alternative to this wrapping type would be to
+/// implement [Serialize]/[Deserialize] directly in that crate under a feature flag.
+#[derive(Clone, Copy, Debug)]
+pub struct SerializableCrc32c(Crc32c);
+
+impl Deref for SerializableCrc32c {
+    type Target = Crc32c;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl From<Crc32c> for SerializableCrc32c {
+    fn from(value: Crc32c) -> Self {
+        SerializableCrc32c(value)
+    }
+}
+
+impl From<SerializableCrc32c> for Crc32c {
+    fn from(value: SerializableCrc32c) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for SerializableCrc32c {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_u32(self.value())
+    }
+}
+
+impl<'de> Deserialize<'de> for SerializableCrc32c {
+    fn deserialize<D: Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let checksum = u32::deserialize(d)?;
+        let checksum = Crc32c::new(checksum);
+        Ok(checksum.into())
+    }
+}


### PR DESCRIPTION
WIP on adding checksums to be written on disk

Introduces a new struct for a block that is serializable using serde. Uses bincode as the on-disk file format.