### PR TITLE
Perf benchmark working branch

### DIFF
--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 from os import path
+import signal
 import subprocess
 from subprocess import Popen, PIPE
 import tempfile
@@ -213,7 +214,8 @@ class ResourceMonitoring():
 
     def _close(self) -> None:
         log.debug("Shutting down resource monitors...")
-        self.mpstat_process.kill()
+        self.mpstat_process.send_signal(signal.SIGINT)
+        self.mpstat_process.wait()
         for output_file in self.output_files:
             output_file.close()
 

--- a/benchmark/benchmark.py
+++ b/benchmark/benchmark.py
@@ -7,7 +7,7 @@ import signal
 import subprocess
 from subprocess import Popen, PIPE
 import tempfile
-from typing import Optional
+from typing import List, Optional
 import urllib.request
 
 import hydra
@@ -204,38 +204,66 @@ def _get_ec2_instance_id() -> Optional[str]:
     return instance_id
 
 class ResourceMonitoring():
-    def __init__(self):
+    def __init__(self, with_bwm: bool):
+        """Resource monitoring setup.
+
+        with_bwm: Whether to start bandwidth monitor tool `bwm-ng`.  Optional because it's not available
+        in the default AL2023 distro so you have to install it first."""
         self.mpstat_process = None
+        self.bwm_ng_process = None
+        self.with_bwm = with_bwm
         self.output_files = []
 
     def _start(self) -> None:
         log.debug("Starting resource monitors...")
         self.mpstat_process = self._start_mpstat()
+        if self.with_bwm:
+            self.bwm_ng_process = self._start_bwm_ng()
 
     def _close(self) -> None:
         log.debug("Shutting down resource monitors...")
-        self.mpstat_process.send_signal(signal.SIGINT)
-        self.mpstat_process.wait()
+        if self.mpstat_process:
+            self.mpstat_process.send_signal(signal.SIGINT)
+            self.mpstat_process.wait()
+        if self.bwm_ng_process:
+            self.bwm_ng_process.send_signal(signal.SIGINT)
+            self.bwm_ng_process.wait()
         for output_file in self.output_files:
             output_file.close()
 
+    def _start_monitor_with_builtim_repeat(self, process_args: List[str], output_file) -> any:
+        """Start process_args with output to output_file.
+
+        Used for starting processes in the background to do monitoring; good for tools that repeat the
+        measurement themselves so only need to be started once, and that can write their output to stdout.
+        """
+        f = open(output_file, 'w')
+        self.output_files.append(f)
+        log.debug(f"Starting monitoring tool {''.join(process_args)}")
+        return subprocess.Popen(process_args, stdout=f)
+
     def _start_mpstat(self) -> any:
-        output_file = open("mpstat.json", "w")
-        self.output_files.append(output_file)
-        process_args = [
-            "/usr/bin/mpstat",
-            "-P", "ALL", # cores
-            "-o", "JSON",
-            "1", # interval
-        ]
-        log.debug(f"Starting mpstat: {' '.join(process_args)}")
-        return subprocess.Popen(process_args, stdout=output_file)
+        return self._start_monitor_with_builtim_repeat([
+                "/usr/bin/mpstat",
+                "-P", "ALL", # cores
+                "-o", "JSON",
+                "1", # interval
+            ], 'mpstat.json')
+
+    def _start_bwm_ng(self) -> any:
+        """Starts bwm-ng, which probably needs to be installed.
+
+        https://www.gropp.org/?id=projects&sub=bwm-ng"""
+        return self._start_monitor_with_builtim_repeat([
+            '/usr/local/bin/bwm-ng',
+            '-o', 'csv'
+            ], 'bwm-ng.csv')
 
     from contextlib import contextmanager
 
     @contextmanager
-    def managed():
-        resource = ResourceMonitoring()
+    def managed(with_bwm=False):
+        resource = ResourceMonitoring(with_bwm)
         try:
             resource._start()
             yield resource
@@ -261,7 +289,7 @@ def run_experiment(cfg: DictConfig) -> None:
     try:
         mp_version = _mount_mp(cfg, metadata, mount_dir)
         metadata["mp_version"] = mp_version
-        with ResourceMonitoring.managed():
+        with ResourceMonitoring.managed(cfg['with_bwm']):
             _run_fio(cfg, mount_dir)
         success = True
     except subprocess.SubprocessError as e:

--- a/benchmark/conf/config.yaml
+++ b/benchmark/conf/config.yaml
@@ -33,6 +33,7 @@ wait_for_profiler_attach: false
 
 # Record perf profiling of all CPUs for the duration of each FIO run
 with_perf: false
+with_bwm: false
 
 stub_reading_mode: off # fuse, s3_client
 


### PR DESCRIPTION
## Description of change

1. Makes `mpstat` stop gracefully, thus writing the terminating braces needed to make the JSON output complete.
2. Add `bwm-ng` as an optional resource monitor so we can gather network bandwidth data.  We might swap this out for another tool in future, but this was convenient for now.

## Does this change impact existing behavior?

No breaking changes.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and I agree to the terms of the [Developer Certificate of Origin (DCO)](https://developercertificate.org/).
